### PR TITLE
[SYNC] Use fzf again, clean up coc settings

### DIFF
--- a/coc-settings.json
+++ b/coc-settings.json
@@ -1,14 +1,5 @@
 {
     "languageserver": {
-        "rust": {
-            "command": "ra_lsp_server",
-            "filetypes": [
-                "rust"
-            ],
-            "rootPatterns": [
-                "Cargo.toml"
-            ]
-        },
         "bash": {
             "command": "bash-language-server",
             "args": [
@@ -44,7 +35,11 @@
         },
         "haskell": {
             "command": "hie-wrapper",
+            "args": [
+                "--lsp"
+            ],
             "rootPatterns": [
+                "stack.yaml",
                 ".stack.yaml",
                 "cabal.config",
                 "package.yaml",
@@ -56,12 +51,8 @@
                 "lhs",
                 "haskell"
             ],
-            "settings": {
-                "languageServerHaskell": {
-                    "hlintOn": false,
-                    "maxNumberOfProblems": 10,
-                    "completionSnippetsOn": true
-                }
+            "initializationOptions": {
+                "languageServerHaskell": {}
             }
         },
         "golang": {

--- a/config/01.plugins.vim
+++ b/config/01.plugins.vim
@@ -6,6 +6,7 @@ filetype off
 set rtp+=/usr/share/vim/vimfiles
 " initialize dein, plugins are installed to this directory
 call dein#begin(expand('~/.cache/dein'))
+
 " add packages here, e.g:
 call dein#add('sheerun/vim-polyglot')
 call dein#add('Shougo/vimshell')
@@ -26,7 +27,7 @@ call dein#add('plasticboy/vim-markdown')
 call dein#add('jamessan/vim-gnupg')
 call dein#add('justinmk/vim-dirvish')
 call dein#add('neoclide/coc.nvim', {'rev': 'release'})
-call dein#add('sakhnik/nvim-gdb', {'do' : 'bash install.sh'})
+call dein#add('puremourning/vimspector', {'do' : 'python3 install_gadget.py --all'})
 call dein#add('tpope/vim-fugitive')
 call dein#add('neovimhaskell/haskell-vim')
 call dein#add('tpope/vim-eunuch')

--- a/config/06.fzf.vim
+++ b/config/06.fzf.vim
@@ -1,0 +1,9 @@
+function! RipgrepFzf(query, fullscreen)
+  let command_fmt = 'rg --column --line-number --no-heading --color=always --smart-case %s || true'
+  let initial_command = printf(command_fmt, shellescape(a:query))
+  let reload_command = printf(command_fmt, '{q}')
+  let spec = {'options': ['--phony', '--query', a:query, '--bind', 'change:reload:'.reload_command]}
+  call fzf#vim#grep(initial_command, 1, fzf#vim#with_preview(spec), a:fullscreen)
+endfunction
+
+command! -nargs=* -bang RG call RipgrepFzf(<q-args>, <bang>0)

--- a/config/08.keybindings.vim
+++ b/config/08.keybindings.vim
@@ -1,0 +1,121 @@
+" Use ; for commands
+nnoremap ; :
+
+" Use the spacebar as the leader key instead of `\`
+map <Space> <Leader>
+
+" split pane navigation
+nnoremap <C-J> <C-W><C-J>
+nnoremap <C-K> <C-W><C-K>
+nnoremap <C-L> <C-W><C-L>
+nnoremap <C-H> <C-W><C-H>
+
+" Delete trailing whitespace with F5
+:nnoremap <silent> <F5> :let _s=@/ <Bar> :%s/\s\+$//e <Bar> :let @/=_s <Bar> :nohl <Bar> :unlet _s <CR>
+
+command! -nargs=0 Format :call CocAction('format')
+
+" Remap keys for gotos
+nmap <silent> gd <Plug>(coc-definition)
+nmap <silent> gy <Plug>(coc-type-definition)
+nmap <silent> gi <Plug>(coc-implementation)
+nmap <silent> gc :call CocAction('format')<CR>
+nmap <leader>rn <Plug>(coc-rename)
+nmap <leader>rf <Plug>(coc-references)
+
+" fzy
+nnoremap <C-p> :Files<Cr>
+nnoremap <C-s> :RG<CR>
+nnoremap <C-m> :Marks<CR>
+
+" neosnippets
+imap <C-l> <Plug>(coc-snippets-expand)
+imap <C-k> <Plug>(coc-snippets-expand-jump)
+inoremap <silent><expr> <TAB>
+    \ pumvisible() ? "\<C-n>" :
+      \ <SID>check_back_space() ? "\<TAB>" :
+      \ coc#refresh()
+inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
+inoremap <expr> <cr> pumvisible() ? "\<C-y>" : "\<C-g>u\<CR>"
+nnoremap <silent> K :call <SID>show_documentation()<CR>
+nmap <silent> [c <Plug>(coc-diagnostic-prev)
+nmap <silent> ]c <Plug>(coc-diagnostic-next)
+
+function! s:show_documentation()
+  if (index(['vim','help'], &filetype) >= 0)
+    execute 'h '.expand('<cword>')
+  else
+    call CocAction('doHover')
+  endif
+endfunction
+
+augroup mygroup
+  autocmd!
+  " Setup formatexpr specified filetype(s).
+  autocmd FileType typescript,json,cpp,c,python,rust,go setl formatexpr=CocAction('formatSelected')
+  " Update signature help on jump placeholder
+  autocmd User CocJumpPlaceholder call CocActionAsync('showSignatureHelp')
+augroup end
+
+" grep word under cursor
+command! -bang -nargs=* Rg
+  \ call fzf#vim#grep(
+  \   'rg --column --line-number --no-heading --color=always --smart-case '.shellescape(<q-args>), 1,
+  \   fzf#vim#with_preview(), <bang>0)
+
+function! s:GrepArgs(...)
+  let list = ['-S', '-smartcase', '-i', '-ignorecase', '-w', '-word',
+        \ '-e', '-regex', '-u', '-skip-vcs-ignores', '-t', '-extension']
+  return join(list, "\n")
+endfunction
+
+vnoremap <leader>g :<C-u>call <SID>GrepFromSelected(visualmode())<CR>
+nnoremap <leader>g :<C-u>set operatorfunc=<SID>GrepFromSelected<CR>g@
+
+function! s:GrepFromSelected(type)
+  let saved_unnamed_register = @@
+  if a:type ==# 'v'
+    normal! `<v`>y
+  elseif a:type ==# 'char'
+    normal! `[v`]y
+  else
+    return
+  endif
+  let word = substitute(@@, '\n$', '', 'g')
+  let word = escape(word, '| ')
+  let @@ = saved_unnamed_register
+  execute 'CocList grep '.word
+endfunction
+
+" Keymapping for grep word under cursor with interactive mode
+nnoremap <silent> <Leader>cf :exe 'CocList -I --input='.expand('<cword>').' grep'<CR>
+nnoremap <silent> <space>w  :exe 'CocList -I --normal --input='.expand('<cword>').' words'<CR>
+
+function! s:check_back_space() abort
+  let col = col('.') - 1
+  return !col || getline('.')[col - 1]  =~# '\s'
+endfunction
+
+" For conceal markers.
+if has('conceal')
+  set conceallevel=2 concealcursor=niv
+endif
+
+" change working directory to where the file in the buffer is located
+" if user types `,cd`
+nnoremap ,cd :cd %:p:h<CR>:pwd<CR>
+
+" Easy most-recent-buffer switching
+nnoremap <Tab> :CocList buffers<CR>
+
+" switch buffers
+map <C-9> :bp<CR>
+map <C-0> :bn<CR>
+
+" Remap for do codeAction of current line
+nmap <leader>ac  <Plug>(coc-codeaction)
+" Fix autofix problem of current line
+nmap <leader>qf  <Plug>(coc-fix-current)
+
+nnoremap <Leader>v :vsplit<CR>
+nnoremap <Leader>h :split<CR>


### PR DESCRIPTION
* Clean up coc and remove langserver configs for languages that already
  have an associated plugin. I didn't realize that this would lead to
  multiple language servers (or multiple instances of the same language
  server being used at the same time). It was very inefficient.
* Use FZF again over coc-lists. Anecdotal evidence shows that coc-lists
  uses a lot of ram in large projects when trying to grep for things.
  FZF seems to be more efficient (might just be a go vs typescript
  thing).
* Update keybindings for the plugin changes
* Add some new plugins, namely vimspector, which provides a debugging
  interface for nvim that aims to be for debuggers what coc is for
  language servers